### PR TITLE
chore: create .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# oprish and effis
+INSTANCE_NAME = eludris
+
+# pandemonium
+GATEWAY_ADDRESS = 127.0.0.1
+GATEWAY_PORT = 7160

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
-# oprish and effis
-INSTANCE_NAME = eludris
+# todel
+ELUDRIS_CONF = Eludris.toml  # the path to your configuration file
 
 # pandemonium
-GATEWAY_ADDRESS = 127.0.0.1
 GATEWAY_PORT = 7160
+GATEWAY_ADDRESS = localhost
+
+# both pandemonium and oprish
+REDIS_URL = redis://127.0.0.1:6379
+
+# oprish
+DATABASE_URL = mysql://root:root@localhost:3306/eludris


### PR DESCRIPTION
Adds a .env.example file with environment variables from effis, oprish and pandemonium.
I added no comments because I think the names are self-explanatory but suggestions are welcome.