### PR TITLE
build(docker): add prebuilt images to ghcr.io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          # Multiple packages.
+          logout: false
 
       - name: Build and Push
         uses: docker/build-push-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ permissions:
 
 jobs:
   buildx:
+    name: Build and Push
+
     strategy:
       matrix:
         service:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
             type=semver,pattern={{major}}
             type=sha,prefix=
             type=sha,format=long,prefix=
-
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'next') }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,68 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "v*.*.*"
+  pull_request:
+    branches:
+      - "main"
+
+permissions:
+  packages: write
+
+jobs:
+  buildx:
+    strategy:
+      matrix:
+        service:
+          - oprish
+          - pandemonium
+          - effis
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Generate Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.service }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=
+            type=sha,format=long,prefix=
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Github Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ${{ matrix.service }}/Dockerfile
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.package }}:latest
+          cache-to: type=inline
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,50 @@
+version: "3"
+
+x-restart-policy:
+  &restart-policy
+  restart: unless-stopped
+
+services:
+  oprish:
+    <<: *restart-policy
+    depends_on: [ "mariadb", "keydb" ]
+
+    environment:
+      - DATABASE_URL=mysql://root:root@mariadb/eludris
+      - REDIS_URL=redis://keydb:6379
+    volumes:
+      - type: bind
+        source: Eludris.toml
+        target: /Eludris.toml
+    build:
+      context: .
+      dockerfile: oprish/Dockerfile
+    pull_policy: build
+
+  pandemonium:
+    extends:
+      service: oprish
+    build:
+      dockerfile: pandemonium/Dockerfile
+
+  effis:
+    extends:
+      service: oprish
+    build:
+      dockerfile: effis/Dockerfile
+
+  keydb:
+    <<: *restart-policy
+    image: eqalpha/keydb
+    volumes:
+      - "./keydb:/data"
+
+  mariadb:
+    <<: *restart-policy
+    image: mariadb:10-jammy
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_ROOT_HOST: "%"
+      MYSQL_DATABASE: eludris
+    volumes:
+      - "./mariadb:/var/lib/mysql"

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -7,18 +7,18 @@ x-pull-policy:
 services:
   oprish:
     <<: *pull-policy
-    image: ghcr.io/Eludris/oprish
+    image: ghcr.io/eludris/oprish
     ports:
       - ${OPRISH_PORT:-7159}:7159
 
   pandemonium:
     <<: *pull-policy
-    image: ghcr.io/Eludris/pandemonium
+    image: ghcr.io/eludris/pandemonium
     ports:
       - ${PANDEMONIUM_PORT:-7160}:7160
 
   effis:
     <<: *pull-policy
-    image: ghcr.io/Eludris/effis
+    image: ghcr.io/eludris/effis
     ports:
       - ${EFFIS_PORT:-7161}:7161

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -1,0 +1,24 @@
+version: "3"
+
+x-pull-policy:
+  &pull-policy
+  pull_policy: always
+
+services:
+  oprish:
+    <<: *pull-policy
+    image: ghcr.io/Eludris/oprish
+    ports:
+      - ${OPRISH_PORT:-7159}:7159
+
+  pandemonium:
+    <<: *pull-policy
+    image: ghcr.io/Eludris/pandemonium
+    ports:
+      - ${PANDEMONIUM_PORT:-7160}:7160
+
+  effis:
+    <<: *pull-policy
+    image: ghcr.io/Eludris/effis
+    ports:
+      - ${EFFIS_PORT:-7161}:7161

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,82 +1,14 @@
 version: "3"
 
-x-conf:
-  &conf
-  type: bind
-  source: Eludris.toml
-  target: /Eludris.toml
-
-x-restart-policy:
-  &restart-policy
-  restart: unless-stopped
-
-x-needs-dbs:
-  &needs-dbs
-  depends_on: ["mariadb", "keydb"]
-
-x-dbs:
-  &dbs
-  DATABASE_URL: "mysql://root:root@mariadb/eludris"
-  REDIS_URL: "redis://keydb:6379"
-
-x-default-service:
-  &default-service
-  <<: *restart-policy
-  <<: *needs-dbs
-
 services:
   oprish:
-    <<: *default-service
-
-    environment: *dbs
     ports:
-      - "7159:7159"
-    volumes:
-      - <<: *conf
-    build:
-      context: .
-      dockerfile: oprish/Dockerfile
-    pull_policy: build
+      - ${OPRISH_PORT:-7159}:7159
 
   pandemonium:
-    <<: *default-service
-
-    environment: *dbs
     ports:
-      - "7160:7160"
-    volumes:
-      - <<: *conf
-    build:
-      context: .
-      dockerfile: pandemonium/Dockerfile
-    pull_policy: build
+      - ${PANDEMONIUM_PORT:-7160}:7160
 
   effis:
-    <<: *default-service
-
-    environment: *dbs
     ports:
-      - "7161:7161"
-    volumes:
-      - <<: *conf
-      - "./files:/files"
-    build:
-      context: .
-      dockerfile: effis/Dockerfile
-    pull_policy: build
-
-  keydb:
-    <<: *restart-policy
-    image: eqalpha/keydb
-    volumes:
-      - "./keydb:/data"
-
-  mariadb:
-    <<: *restart-policy
-    image: mariadb:10-jammy
-    environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_ROOT_HOST: "%"
-      MYSQL_DATABASE: eludris
-    volumes:
-      - "./mariadb:/var/lib/mysql"
+      - ${EFFIS_PORT:-7161}:7161

--- a/effis/Dockerfile
+++ b/effis/Dockerfile
@@ -25,13 +25,7 @@ FROM debian:buster-slim
 
 COPY ./wait-for-it.sh ./
 
-# Don't forget to also publish these ports in the docker-compose.yml file.
-ARG PORT=7161
-
-EXPOSE $PORT
 ENV ROCKET_ADDRESS 0.0.0.0
-ENV ROCKET_PORT $PORT
-
 ENV RUST_LOG debug
 
 COPY --from=builder /usr/local/bin/effis /bin/effis

--- a/oprish/Dockerfile
+++ b/oprish/Dockerfile
@@ -24,13 +24,7 @@ FROM debian:buster-slim
 
 COPY ./wait-for-it.sh ./
 
-# Don't forget to also publish these ports in the docker-compose.yml file.
-ARG PORT=7159
-
-EXPOSE $PORT
 ENV ROCKET_ADDRESS 0.0.0.0
-ENV OPRISH_PORT $PORT
-
 ENV RUST_LOG debug
 
 COPY --from=builder /usr/local/bin/oprish /bin/oprish

--- a/pandemonium/Dockerfile
+++ b/pandemonium/Dockerfile
@@ -23,14 +23,8 @@ RUN --mount=type=cache,target=/target \
 FROM debian:buster-slim
 
 COPY ./wait-for-it.sh ./
- 
-# Don't forget to also publish these ports in the docker-compose.yml file.
-ARG PORT=7160
 
-EXPOSE $PORT
 ENV PANDEMONIUM_ADDRESS 0.0.0.0
-ENV PANDEMONIUM_PORT $PORT
-
 ENV RUST_LOG debug
 
 COPY --from=builder /usr/local/bin/pandemonium /bin/pandemonium


### PR DESCRIPTION
This splits `docker-compose.yml` into 3 files. `docker-compose.override.yml` does not define ports so it can utilise `extends` since oprish, pand, and effiw are very similar in setup. `docker-compose.prebuilt.yml` uses the `ghcr.io` images and `docker-compose.yml` builds the images locally.

The CI in `.github/workflows/build.yml` uses a matrix for all 3 microservices. `logout: false` resolves weird magic when the second and third services try to push, and the first service built logs out. Metadata's `tags` is documented in <https://github.com/docker/metadata-action>, semver tags will be made when a git tag is pushed - ideally with GitHub releases.

This also refactors `Dockerfile`s to remove the `PORT` arg - since that requires a re-build and compose can simply pass through.

Enoki based.
