### PR TITLE
chore: add pr & issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,8 @@ body:
       options:
         - Deployment
         - Effiw
-        - 
+        - Effis
+        - Eludris
 
   - type: checkboxes
     label: Checks

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,12 +18,13 @@ body:
         - Eludris
 
   - type: checkboxes
-    label: Checks
-    options:
-      - label: Have you checked the documentation?
-        required: true
-      - label: Have you checked other issues to make sure this is not a duplicate?
-        required: true
+    attributes:
+      label: Checks
+      options:
+        - label: Have you checked the documentation?
+          required: true
+        - label: Have you checked other issues to make sure this is not a duplicate?
+          required: true
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,9 +20,9 @@ body:
   - type: checkboxes
     label: Checks
     options:
-      - Have you checked the documentation?
+      - label: Have you checked the documentation?
         required: true
-      - Have you checked other issues to make sure this is not a duplicate?
+      - label: Have you checked other issues to make sure this is not a duplicate?
         required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,9 @@ body:
       options:
         - Deployment
         - Effis
-        - Eludris
+        - Todel
+        - Pandemonium
+        - Oprish
 
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,33 @@
+name: Bug Report
+description: Report any bugs you encounter.
+body:
+  - type: textarea
+    attributes:
+      label: What is the issue?
+      description: Insert a detailed description of what your issue is
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: What is the issue with?
+      options:
+        - Deployment
+        - Effiw
+        - 
+
+  - type: checkboxes
+    label: Checks
+    options:
+      - Have you checked the documentation?
+        required: true
+      - Have you checked other issues to make sure this is not a duplicate?
+        required: true
+
+  - type: textarea
+    attributes:
+      label: Minimum Reproduction
+      description: Insert any code or steps to produce this issue.
+    validations:
+      required: true
+      

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,7 +29,7 @@ body:
 
   - type: textarea
     attributes:
-      label: Minimum Reproduction
+      label: Minimum Reproducible Sample/Code
       description: Insert any code or steps to help reproduce this issue.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report any bugs you encounter.
+description: Please enter the details of your bug
 body:
   - type: textarea
     attributes:
@@ -12,11 +12,12 @@ body:
     attributes:
       label: What is the issue with?
       options:
-        - Deployment
+        - CI
         - Effis
         - Todel
         - Pandemonium
         - Oprish
+        - CLI
 
   - type: checkboxes
     attributes:
@@ -30,7 +31,7 @@ body:
   - type: textarea
     attributes:
       label: Minimum Reproducible Sample/Code
-      description: Insert any code or steps to help reproduce this issue.
+      description: Insert any code or steps to help reproduce this issue
     validations:
       required: true
       

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,6 @@ body:
       label: What is the issue with?
       options:
         - Deployment
-        - Effiw
         - Effis
         - Eludris
 
@@ -29,7 +28,7 @@ body:
   - type: textarea
     attributes:
       label: Minimum Reproduction
-      description: Insert any code or steps to produce this issue.
+      description: Insert any code or steps to help reproduce this issue.
     validations:
       required: true
       

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,7 @@ body:
       required: true
 
   - type: textarea
-    atttributes:
+    attributes:
       label: Why?
       description: Explain why you want this to be added
     validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,20 @@
+name: Feature Request
+description: Request a feature that you would like Eludris to support
+body:
+  - type: input
+    attributes:
+      label: What would you like to be added?
+    validations:
+      required: true
+
+  - type: textarea
+    atttributes:
+      label: Why?
+      description: Explain why you want this to be added
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Examples
+      description: Add any examples (photos, videos, etc.) of your feature

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature Request
-description: Request a feature that you would like Eludris to support
+description: Please enter the details of the feature you want added
 body:
   - type: input
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Description
+
+<!-- Explain what this Pull Request changes -->
+
+<!-- Link any issues if applicable.
+Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
+-->
+
+<!-- Uncomment based on the type of your changes below -->
+
+<!--
+## This is a **Code Change**
+
+- [ ] Docs have been updated if they need to be. 
+- [ ] Changes have been tested.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,6 @@ Use keywords from https://docs.github.com/en/get-started/writing-on-github/worki
 <!--
 ## This is a **Code Change**
 
-- [ ] Docs have been updated if they need to be. 
+- [ ] Docs have been updated to reflect these changes if necessary.
 - [ ] Changes have been tested.
 -->


### PR DESCRIPTION
This adds PR and Issue templates that will be used when one creates a bug report/feature request issue, or a pull request.

- Closes #29 