### PR TITLE
Switch pandemonium away from using a pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,7 +644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a62ebf187bc30bfc1a14bed4073912b988551d111208fe800b27c32df282481"
 dependencies = [
  "deadpool",
- "redis",
+ "redis 0.21.7",
 ]
 
 [[package]]
@@ -1903,11 +1903,11 @@ name = "pandemonium"
 version = "0.3.2"
 dependencies = [
  "anyhow",
- "deadpool-redis",
  "dotenvy",
  "env_logger 0.9.3",
  "futures",
  "log",
+ "redis 0.22.3",
  "serde",
  "serde_json",
  "todel",
@@ -2258,6 +2258,26 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "ryu",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "redis"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa8455fa3621f6b41c514946de66ea0531f57ca017b2e6c7cc368035ea5b46df"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "combine",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
  "tokio",
  "tokio-util",
  "url",
@@ -2745,6 +2765,12 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.6",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"

--- a/pandemonium/Cargo.toml
+++ b/pandemonium/Cargo.toml
@@ -8,11 +8,11 @@ documentation.workspace = true
 
 [dependencies]
 anyhow = "1.0.66"
-deadpool-redis = "0.10.2"
 dotenvy = "0.15.6"
 env_logger = "0.9.0"
 futures = "0.3.24"
 log = "0.4.17"
+redis = { version = "0.22.3", features = ["tokio-comp"] }
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
 todel = { features = ["logic"], version = "0.3.0", path = "../todel" }

--- a/pandemonium/src/handle_connection.rs
+++ b/pandemonium/src/handle_connection.rs
@@ -87,7 +87,7 @@ pub async fn handle_connection(
     );
     if let Err(()) = rate_limiter.process_rate_limit().await {
         log::info!(
-            "Disconnected a client: {}, reason: Hit rate_limit",
+            "Disconnected a client: {}. Reason: Client is already rate limited",
             rl_address
         );
         return;

--- a/pandemonium/src/handle_connection.rs
+++ b/pandemonium/src/handle_connection.rs
@@ -1,7 +1,7 @@
-use deadpool_redis::redis::aio::PubSub;
-use deadpool_redis::Connection;
 use futures::stream::{SplitSink, SplitStream};
 use futures::{SinkExt, StreamExt};
+use redis::aio::Connection;
+use redis::aio::PubSub;
 use std::borrow::Cow;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;

--- a/pandemonium/src/rate_limit.rs
+++ b/pandemonium/src/rate_limit.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use deadpool_redis::{redis::AsyncCommands, Connection};
+use redis::{aio::Connection, AsyncCommands};
 
 /// A simple RateLimiter than can keep track of rate limit data from KeyDB
 pub struct RateLimiter {

--- a/pandemonium/src/utils.rs
+++ b/pandemonium/src/utils.rs
@@ -1,4 +1,4 @@
-use deadpool_redis::redis::Msg;
+use redis::Msg;
 use std::{error::Error, fmt::Display};
 use todel::models::Payload;
 


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request changes -->

This is done to avoid a bug where pandemonium hits the pool connection
limit which makes it hang until more connections can be found when all
of them are currently being used.

This commit entails moving away from `deadpool-redis` and using a
manually managed `redis` aio client.


<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

## This is a **Code Change**

- ~~[ ] Docs have been updated to reflect these changes if necessary.~~ refer to #37
- [x] Changes have been tested.

