### PR TITLE
feat: improve how errors are wrapped when mapped

### DIFF
--- a/effis/src/rate_limit.rs
+++ b/effis/src/rate_limit.rs
@@ -165,8 +165,8 @@ impl RateLimiter {
         }
     }
 
-    pub fn wrap_response<T, E>(&self, data: T) -> Result<RateLimitHeaderWrapper<T>, E> {
-        Ok(RateLimitHeaderWrapper {
+    pub fn add_headers<T>(&self, data: T) -> RateLimitHeaderWrapper<T> {
+        RateLimitHeaderWrapper {
             inner: data,
             rate_limit_reset: Header::new(
                 "X-RateLimit-Reset",
@@ -189,6 +189,10 @@ impl RateLimiter {
                 "X-RateLimit-Sent-Bytes",
                 self.sent_bytes.to_string(),
             ),
-        })
+        }
+    }
+
+    pub fn wrap_response<T, E>(&self, data: T) -> Result<RateLimitHeaderWrapper<T>, E> {
+        Ok(self.add_headers(data))
     }
 }

--- a/effis/src/routes/buckets.rs
+++ b/effis/src/routes/buckets.rs
@@ -27,7 +27,7 @@ pub async fn upload<'a>(
     rate_limiter
         .process_rate_limit(upload.file.len(), &mut cache)
         .await?;
-    check_bucket(bucket).map_err(|e| rate_limiter.wrap_response::<_, ()>(e).unwrap())?;
+    check_bucket(bucket).map_err(|e| rate_limiter.add_headers(e))?;
     let upload = upload.into_inner();
     let file = File::create(
         upload.file,
@@ -37,7 +37,7 @@ pub async fn upload<'a>(
         upload.spoiler,
     )
     .await
-    .map_err(|e| rate_limiter.wrap_response::<_, ()>(e).unwrap())?;
+    .map_err(|e| rate_limiter.add_headers(e))?;
     rate_limiter.wrap_response(Json(file))
 }
 
@@ -52,10 +52,10 @@ pub async fn get<'a>(
 ) -> RateLimitedRouteResponse<FetchResponse<'a>> {
     let mut rate_limiter = RateLimiter::new("fetch_file", bucket, ip, conf.inner());
     rate_limiter.process_rate_limit(0, &mut cache).await?;
-    check_bucket(bucket).map_err(|e| rate_limiter.wrap_response::<_, ()>(e).unwrap())?;
+    check_bucket(bucket).map_err(|e| rate_limiter.add_headers(e))?;
     let file = File::fetch_file(id, bucket, &mut db)
         .await
-        .map_err(|e| rate_limiter.wrap_response::<_, ()>(e).unwrap())?;
+        .map_err(|e| rate_limiter.add_headers(e))?;
     rate_limiter.wrap_response(file)
 }
 
@@ -70,10 +70,10 @@ pub async fn download<'a>(
 ) -> RateLimitedRouteResponse<FetchResponse<'a>> {
     let mut rate_limiter = RateLimiter::new("fetch_file", bucket, ip, conf.inner());
     rate_limiter.process_rate_limit(0, &mut cache).await?;
-    check_bucket(bucket).map_err(|e| rate_limiter.wrap_response::<_, ()>(e).unwrap())?;
+    check_bucket(bucket).map_err(|e| rate_limiter.add_headers(e))?;
     let file = File::fetch_file_download(id, bucket, &mut db)
         .await
-        .map_err(|e| rate_limiter.wrap_response::<_, ()>(e).unwrap())?;
+        .map_err(|e| rate_limiter.add_headers(e))?;
     rate_limiter.wrap_response(file)
 }
 
@@ -88,10 +88,10 @@ pub async fn get_data<'a>(
 ) -> RateLimitedRouteResponse<Json<FileData>> {
     let mut rate_limiter = RateLimiter::new("fetch_file", bucket, ip, conf.inner());
     rate_limiter.process_rate_limit(0, &mut cache).await?;
-    check_bucket(bucket).map_err(|e| rate_limiter.wrap_response::<_, ()>(e).unwrap())?;
+    check_bucket(bucket).map_err(|e| rate_limiter.add_headers(e))?;
     let file = File::fetch_file_data(id, bucket, &mut db)
         .await
-        .map_err(|e| rate_limiter.wrap_response::<_, ()>(e).unwrap())?;
+        .map_err(|e| rate_limiter.add_headers(e))?;
     rate_limiter.wrap_response(Json(file))
 }
 

--- a/effis/src/routes/index.rs
+++ b/effis/src/routes/index.rs
@@ -35,7 +35,7 @@ pub async fn upload_attachment<'a>(
         upload.spoiler,
     )
     .await
-    .map_err(|e| rate_limiter.wrap_response::<_, ()>(e).unwrap())?;
+    .map_err(|e| rate_limiter.add_headers(e))?;
     rate_limiter.wrap_response(Json(file))
 }
 
@@ -51,7 +51,7 @@ pub async fn get_attachment<'a>(
     rate_limiter.process_rate_limit(0, &mut cache).await?;
     let file = File::fetch_file(id, "attachments", &mut db)
         .await
-        .map_err(|e| rate_limiter.wrap_response::<_, ()>(e).unwrap())?;
+        .map_err(|e| rate_limiter.add_headers(e))?;
     rate_limiter.wrap_response(file)
 }
 
@@ -67,7 +67,7 @@ pub async fn download_attachment<'a>(
     rate_limiter.process_rate_limit(0, &mut cache).await?;
     let file = File::fetch_file_download(id, "attachments", &mut db)
         .await
-        .map_err(|e| rate_limiter.wrap_response::<_, ()>(e).unwrap())?;
+        .map_err(|e| rate_limiter.add_headers(e))?;
     rate_limiter.wrap_response(file)
 }
 
@@ -83,6 +83,6 @@ pub async fn get_attachment_data<'a>(
     rate_limiter.process_rate_limit(0, &mut cache).await?;
     let file = File::fetch_file_data(id, "attachments", &mut db)
         .await
-        .map_err(|e| rate_limiter.wrap_response::<_, ()>(e).unwrap())?;
+        .map_err(|e| rate_limiter.add_headers(e))?;
     rate_limiter.wrap_response(Json(file))
 }

--- a/effis/src/routes/static_routes.rs
+++ b/effis/src/routes/static_routes.rs
@@ -39,7 +39,7 @@ pub async fn get_static_file<'a>(
         content_type,
     } = get_file(name)
         .await
-        .map_err(|e| rate_limiter.wrap_response::<_, ()>(e).unwrap())?;
+        .map_err(|e| rate_limiter.add_headers(e))?;
 
     rate_limiter.wrap_response(FetchResponse {
         file,
@@ -70,7 +70,7 @@ pub async fn download_static_file<'a>(
         content_type,
     } = get_file(name)
         .await
-        .map_err(|e| rate_limiter.wrap_response::<_, ()>(e).unwrap())?;
+        .map_err(|e| rate_limiter.add_headers(e))?;
 
     rate_limiter.wrap_response(Ok(FetchResponse {
         file,

--- a/oprish/src/rate_limit.rs
+++ b/oprish/src/rate_limit.rs
@@ -121,8 +121,8 @@ impl RateLimiter {
     }
 
     /// Wraps a response in a RateLimitHeaderWrapper which adds headers relevant to rate limiting
-    pub fn wrap_response<T, E>(&self, data: T) -> Result<RateLimitHeaderWrapper<T>, E> {
-        Ok(RateLimitHeaderWrapper {
+    pub fn add_headers<T>(&self, data: T) -> RateLimitHeaderWrapper<T> {
+        RateLimitHeaderWrapper {
             inner: data,
             rate_limit_reset: Header::new(
                 "X-RateLimit-Reset",
@@ -137,6 +137,10 @@ impl RateLimiter {
                 "X-RateLimit-Request-Count",
                 self.request_count.to_string(),
             ),
-        })
+        }
+    }
+
+    pub fn wrap_response<T, E>(&self, data: T) -> Result<RateLimitHeaderWrapper<T>, E> {
+        Ok(self.add_headers(data))
     }
 }


### PR DESCRIPTION
## Description

This PR cleans up the code a bit by adding a `RateLimiter::add_headers` which makes wrapping errors with ratelimit headers cleaner when they're mapped.

### Why is this good?

No `::<_, ()>` :D

<!-- Explain what this Pull Request changes -->

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

## This is a **Code Change**

- [x] Docs have been updated to reflect these changes if necessary.
- [x] Changes have been tested.

