### PR TITLE
feat(pandemonium): share one connection for writing and reading ratelimit info

### DIFF
--- a/pandemonium/src/handle_connection.rs
+++ b/pandemonium/src/handle_connection.rs
@@ -47,7 +47,7 @@ async fn check_connection(last_ping: Arc<Mutex<Instant>>) {
 pub async fn handle_connection(
     stream: TcpStream,
     addr: SocketAddr,
-    cache: Connection,
+    cache: Arc<Mutex<Connection>>,
     pubsub: PubSub,
     conf: Arc<Conf>,
 ) {

--- a/pandemonium/src/main.rs
+++ b/pandemonium/src/main.rs
@@ -55,6 +55,7 @@ async fn main() -> Result<(), anyhow::Error> {
             pubsub,
             Arc::clone(&conf),
         ));
+        log::trace!("Spawned connection handling task for {}", addr);
     }
 
     Ok(())


### PR DESCRIPTION
## Description

2 connections / user -> 1 connection / user

This may fix the pandemonium bug

<!-- Explain what this Pull Request changes -->

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

## This is a **Code Change**

- [x] Docs have been updated to reflect these changes if necessary.
- [x] Changes have been tested.
