### PR TITLE
ci(build): use gha cache backend for docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,8 +65,8 @@ jobs:
         with:
           context: .
           file: ${{ matrix.service }}/Dockerfile
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.package }}:latest
-          cache-to: type=inline
+          cache-from: type=gha
+          cache-to: type=gha
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Description

> In most cases you want to use the inline cache exporter.

Docker copied from moby/buildkit docs, yet the docker docs was referring to **GitHub Actions** which has it's own cache backend more well suited for GitHub contexts - handling PR scopes, tags, branches, ... instead of only utlilising a registry's latest published build.

<!-- Explain what this Pull Request changes -->

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

<!--
## This is a **Code Change**

- [ ] Docs have been updated to reflect these changes if necessary.
- [ ] Changes have been tested.
-->
