### PR TITLE
ci(build-cli): use correct env var for windows bin

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           echo "$env:GITHUB_ENV"
           echo ("TAG=" + $env:GITHUB_REF.replace('refs/tags/', '')) >> $env:GITHUB_ENV
-          echo "PATH=eludris.exe" >> $env:GITHUB_ENV
+          echo "CLI_PATH=eludris.exe" >> $env:GITHUB_ENV
           echo "OS=Windows" >> $env:GITHUB_ENV
         if: matrix.os == 'windows-latest'
 


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request changes -->

Since Windows support was not initially added, the commented out step for Windows was not updated with the new environment variable `CLI_PATH`. This fixes it so it uploads properly (and does not upload 1GB of a dir to GitHub :skull:)

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

<!--
## This is a **Code Change**

- [ ] Docs have been updated to reflect these changes if necessary.
- [ ] Changes have been tested.
-->
