### PR TITLE
feat: move migration handling from Effis over to Oprish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,7 +583,6 @@ dependencies = [
  "rocket_db_pools",
  "serde",
  "serde_json",
- "sqlx",
  "todel",
  "tokio",
 ]
@@ -1610,6 +1609,7 @@ dependencies = [
  "rocket_db_pools",
  "serde",
  "serde_json",
+ "sqlx",
  "todel",
  "tokio",
 ]

--- a/effis/Cargo.toml
+++ b/effis/Cargo.toml
@@ -15,6 +15,5 @@ log = "0.4.17"
 rocket = { version = "0.5.0-rc.2", features = ["json"] }
 rocket_db_pools = { version = "0.1.0-rc.2", features = ["deadpool_redis", "sqlx_mysql"] }
 tokio = { version = "1.21.2", features = ["sync", "rt-multi-thread", "macros"] }
-sqlx = { version = "0.6.3", features = ["runtime-tokio-rustls", "macros", "mysql", "offline"] }
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"

--- a/effis/Dockerfile
+++ b/effis/Dockerfile
@@ -11,7 +11,6 @@ COPY ./integration-tests/Cargo.toml /integration-tests/Cargo.toml
 RUN mkdir /oprish/src /pandemonium/src /cli/src /integration-tests/src
 RUN touch /oprish/src/main.rs /pandemonium/src/main.rs /cli/src/main.rs /integration-tests/src/main.rs
 
-COPY ./migrations /migrations
 COPY ./Cargo.toml /Cargo.toml
 COPY ./Cargo.lock /Cargo.lock
 COPY ./todel /todel

--- a/effis/src/main.rs
+++ b/effis/src/main.rs
@@ -103,17 +103,6 @@ async fn main() -> Result<(), anyhow::Error> {
     dotenvy::dotenv().ok();
     env_logger::init();
 
-    let db_url = env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:root@localhost:3306/eludris".to_string());
-
-    let pool = MySqlPool::connect(&db_url)
-        .await
-        .with_context(|| format!("Failed to connect to database on {}", db_url))?;
-    sqlx::migrate!("../migrations")
-        .run(&pool)
-        .await
-        .context("Failed to run migrations")?;
-
     create_file_dirs()?;
 
     let _ = rocket()?

--- a/oprish/Cargo.toml
+++ b/oprish/Cargo.toml
@@ -13,7 +13,8 @@ serde_json = "1.0.85"
 log = "0.4.17"
 env_logger = "0.10.0"
 todel = { features = ["http"], path = "../todel", version = "0.3.0" }
-rocket_db_pools = { version = "0.1.0-rc.2", features = ["deadpool_redis"] }
+rocket_db_pools = { version = "0.1.0-rc.2", features = ["deadpool_redis", "sqlx", "sqlx_mysql"] }
 anyhow = "1.0.71"
 tokio = { version = "1.22.0", features = ["rt-multi-thread", "macros"] }
 dotenvy = "0.15.7"
+sqlx = { version = "0.6.3", features = ["mysql", "macros"] }

--- a/oprish/Dockerfile
+++ b/oprish/Dockerfile
@@ -11,6 +11,7 @@ COPY ./integration-tests/Cargo.toml /integration-tests/Cargo.toml
 RUN mkdir /pandemonium/src /effis/src /cli/src /integration-tests/src
 RUN touch /pandemonium/src/main.rs /effis/src/main.rs /cli/src/main.rs /integration-tests/src/main.rs
 
+COPY ./migrations /migrations
 COPY ./Cargo.toml /Cargo.toml
 COPY ./Cargo.lock /Cargo.lock
 COPY ./todel /todel

--- a/oprish/src/database.rs
+++ b/oprish/src/database.rs
@@ -1,0 +1,33 @@
+use rocket::{
+    fairing::{Fairing, Info, Kind, Result},
+    Build, Rocket,
+};
+use rocket_db_pools::Database;
+
+use crate::DB;
+
+pub struct DatabaseFairing;
+
+#[rocket::async_trait]
+impl Fairing for DatabaseFairing {
+    fn info(&self) -> Info {
+        Info {
+            name: "Handle database migrations & setup",
+            kind: Kind::Ignite,
+        }
+    }
+
+    async fn on_ignite(&self, rocket: Rocket<Build>) -> Result {
+        if let Some(db) = DB::fetch(&rocket) {
+            if let Err(err) = sqlx::migrate!("../migrations").run(&db.0).await {
+                log::error!("Could not run migrations: {}", err);
+                Err(rocket)
+            } else {
+                Ok(rocket)
+            }
+        } else {
+            log::error!("Could not obtain the database for migrations");
+            Err(rocket)
+        }
+    }
+}


### PR DESCRIPTION
## Description

This pull request moves the handling of database migrations from Effis to Oprish as per [this message](https://discord.com/channels/980412957060137001/980412957794136087/1110832622281703504).

Additionally, migration logic has been moved into a [rocket fairing](https://rocket.rs/v0.5-rc/guide/fairings/) since before a pool would be created and would persist for the entire lifetime of Effis.

## This is a **Code Change**

- [x] Docs have been updated to reflect these changes if necessary.
- [x] Changes have been tested.
