### PR TITLE
chore(docker): make pandemonium and effis depend on oprish

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,12 +24,14 @@ services:
   pandemonium:
     extends:
       service: oprish
+    depends_on: [ "mariadb", "keydb", "oprish" ]
     build:
       dockerfile: pandemonium/Dockerfile
 
   effis:
     extends:
       service: oprish
+    depends_on: [ "mariadb", "keydb", "oprish" ]
     volumes:
       - type: bind
         source: ./files

--- a/docs/src/content/extra/detailed.md
+++ b/docs/src/content/extra/detailed.md
@@ -123,6 +123,7 @@ All of the microservices' source code can be found in the [Eludris meta-reposito
 Eludris uses JWT tokens to authenticate users.
 These tokens are required for nearly every interaction.
 Trying to connect to the Gateway or interact with the API? You'll need a token!
+The JWT tokens used within our services use a cryptographically secure pseudo-random string with a randomly generated HC128 string as a secret.
 
 If you wish to get a new token, send an HTTP request to `/auth` with your email and password.
 

--- a/docs/src/content/extra/detailed.md
+++ b/docs/src/content/extra/detailed.md
@@ -123,7 +123,6 @@ All of the microservices' source code can be found in the [Eludris meta-reposito
 Eludris uses JWT tokens to authenticate users.
 These tokens are required for nearly every interaction.
 Trying to connect to the Gateway or interact with the API? You'll need a token!
-The JWT tokens used within our services use a cryptographically secure pseudo-random string with a randomly generated HC128 string as a secret.
 
 If you wish to get a new token, send an HTTP request to `/auth` with your email and password.
 


### PR DESCRIPTION
## Description

This PR aims to make it so that the other microservices run after oprish has run since oprish now handles stuff like migrations