### PR TITLE
build(compose): use restart unless-stopped

### DIFF
--- a/docker-compose.next.yml
+++ b/docker-compose.next.yml
@@ -1,24 +1,17 @@
 version: "3"
 
-x-pull-policy:
-  &pull-policy
-  pull_policy: always
-
 services:
   oprish:
-    <<: *pull-policy
     image: ghcr.io/eludris/oprish:next
     ports:
       - ${OPRISH_PORT:-7159}:7159
 
   pandemonium:
-    <<: *pull-policy
     image: ghcr.io/eludris/pandemonium:next
     ports:
       - ${PANDEMONIUM_PORT:-7160}:7160
 
   effis:
-    <<: *pull-policy
     image: ghcr.io/eludris/effis:next
     ports:
       - ${EFFIS_PORT:-7161}:7161

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -1,24 +1,17 @@
 version: "3"
 
-x-pull-policy:
-  &pull-policy
-  pull_policy: always
-
 services:
   oprish:
-    <<: *pull-policy
     image: ghcr.io/eludris/oprish:main
     ports:
       - ${OPRISH_PORT:-7159}:7159
 
   pandemonium:
-    <<: *pull-policy
     image: ghcr.io/eludris/pandemonium:main
     ports:
       - ${PANDEMONIUM_PORT:-7160}:7160
 
   effis:
-    <<: *pull-policy
     image: ghcr.io/eludris/effis:main
     ports:
       - ${EFFIS_PORT:-7161}:7161


### PR DESCRIPTION
## Description

There is no need to duplicate `restart:`, and `unless-stopped` makes more sense over `always`.

<!-- Explain what this Pull Request changes -->

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

<!--
## This is a **Code Change**

- [ ] Docs have been updated to reflect these changes if necessary.
- [ ] Changes have been tested.
-->
