### PR TITLE
feat(cli): improve how the CLI's config directory is handled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,6 +566,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +625,8 @@ dependencies = [
  "clap",
  "console",
  "dialoguer",
+ "directories",
+ "dotenvy",
  "env_logger",
  "indicatif",
  "log",
@@ -1615,6 +1638,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +1990,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.16",
+ "thiserror",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,6 +20,8 @@ anyhow = "1.0.71"
 clap = { version = "4.1.1", features = ["derive"] }
 console = "0.15.5"
 dialoguer = "0.10.3"
+directories = "5.0.1"
+dotenvy = "0.15.7"
 env_logger = "0.10.0"
 indicatif = "0.17.3"
 log = "0.4.17"

--- a/cli/README.md
+++ b/cli/README.md
@@ -25,3 +25,8 @@ or by running the help command:
 ```sh
 eludris --help
 ```
+
+The default CLI config directory can be returned using the `eludris conf-dir` command.
+You can also change the config directory using the `ELUDRIS_CLI_CONF` environment variable.
+
+The CLI automatically reads any `.env` files in the current directory.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -18,7 +18,7 @@ pub struct Config {
     pub eludris_dir: String,
 }
 
-pub fn get_conf_directory() -> Result<PathBuf> {
+pub fn get_config_directory() -> Result<PathBuf> {
     // `ELUDRIS_CLI_CONF` here tries to follow `ELUDRIS_CONF` from `/todel/src/conf/mod.rs`
     match env::var("ELUDRIS_CLI_CONF") {
         Ok(dir) => Ok(PathBuf::try_from(dir).context(
@@ -37,7 +37,7 @@ pub fn get_conf_directory() -> Result<PathBuf> {
 }
 
 pub async fn get_user_config() -> Result<Option<Config>> {
-    let config_dir = get_conf_directory()?;
+    let config_dir = get_config_directory()?;
 
     if !config_dir.exists() {
         fs::create_dir_all(&config_dir)
@@ -60,7 +60,7 @@ pub async fn get_user_config() -> Result<Option<Config>> {
 }
 
 pub async fn update_config_file(config: &Config) -> Result<()> {
-    let config_dir = get_conf_directory()?;
+    let config_dir = get_config_directory()?;
 
     if !config_dir.exists() {
         fs::create_dir_all(&config_dir)

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -18,23 +18,26 @@ pub struct Config {
     pub eludris_dir: String,
 }
 
-pub fn get_conf_directry() -> Result<PathBuf> {
+pub fn get_conf_directory() -> Result<PathBuf> {
     // `ELUDRIS_CLI_CONF` here tries to follow `ELUDRIS_CONF` from `/todel/src/conf/mod.rs`
     match env::var("ELUDRIS_CLI_CONF") {
-        Ok(dir) => Ok(PathBuf::try_from(dir)
-            .context("Could not convert the provided directory into a valid path")?),
+        Ok(dir) => Ok(PathBuf::try_from(dir).context(
+            "Could not convert the `ELUDRIS_CLI_CONF` environment variable into a valid path",
+        )?),
         Err(env::VarError::NotPresent) => Ok(ProjectDirs::from("", "eludris", "eludris")
-            .context("Could not find a valid home directory")?
+            // According to the `directories` docs the error is raised when a home path isn't found
+            // but that wouldn't make much sense for windows so we use `base` here.
+            .context("Could not find a valid base directory")?
             .config_dir()
             .to_path_buf()),
         Err(env::VarError::NotUnicode(_)) => {
-            bail!("The value of the `ELUDRIS_CLI_CONFIG` environment variable mut be valid unicode")
+            bail!("The value of the `ELUDRIS_CLI_CONF` environment variable must be valid unicode")
         }
     }
 }
 
 pub async fn get_user_config() -> Result<Option<Config>> {
-    let config_dir = get_conf_directry()?;
+    let config_dir = get_conf_directory()?;
 
     if !config_dir.exists() {
         fs::create_dir_all(&config_dir)
@@ -57,7 +60,7 @@ pub async fn get_user_config() -> Result<Option<Config>> {
 }
 
 pub async fn update_config_file(config: &Config) -> Result<()> {
-    let config_dir = get_conf_directry()?;
+    let config_dir = get_conf_directory()?;
 
     if !config_dir.exists() {
         fs::create_dir_all(&config_dir)

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -31,7 +31,7 @@ pub fn get_conf_directory() -> Result<PathBuf> {
             .config_dir()
             .to_path_buf()),
         Err(env::VarError::NotUnicode(_)) => {
-            bail!("The value of the `ELUDRIS_CLI_CONF` environment variable must be valid unicode")
+            bail!("The value of the `ELUDRIS_CLI_CONF` environment variable must be a valid unicode string")
         }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,7 +15,7 @@ use anyhow::Context;
 use clap::{Parser, Subcommand};
 use console::Style;
 use dialoguer::{theme, Input};
-use eludris::{get_conf_directory, get_user_config, update_config_file, Config};
+use eludris::{get_config_directory, get_user_config, update_config_file, Config};
 use tokio::fs;
 
 #[derive(Parser)]
@@ -137,7 +137,7 @@ async fn main() -> anyhow::Result<()> {
             AttachmentSubcommand::Remove { id } => attachments::remove(id).await?,
         },
         Commands::Clean => clean::clean().await?,
-        Commands::ConfDir => println!("{}", get_conf_directory()?.display()),
+        Commands::ConfDir => println!("{}", get_config_directory()?.display()),
     }
 
     Ok(())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,7 +15,7 @@ use anyhow::Context;
 use clap::{Parser, Subcommand};
 use console::Style;
 use dialoguer::{theme, Input};
-use eludris::{get_conf_directry, get_user_config, update_config_file, Config};
+use eludris::{get_conf_directory, get_user_config, update_config_file, Config};
 use tokio::fs;
 
 #[derive(Parser)]
@@ -137,7 +137,7 @@ async fn main() -> anyhow::Result<()> {
             AttachmentSubcommand::Remove { id } => attachments::remove(id).await?,
         },
         Commands::Clean => clean::clean().await?,
-        Commands::ConfDir => println!("{}", get_conf_directry()?.display()),
+        Commands::ConfDir => println!("{}", get_conf_directory()?.display()),
     }
 
     Ok(())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,7 +15,7 @@ use anyhow::Context;
 use clap::{Parser, Subcommand};
 use console::Style;
 use dialoguer::{theme, Input};
-use eludris::{get_user_config, update_config_file, Config};
+use eludris::{get_conf_directry, get_user_config, update_config_file, Config};
 use tokio::fs;
 
 #[derive(Parser)]
@@ -62,6 +62,8 @@ enum Commands {
     /// Removes all info related to your Eludris instance
     #[command(alias = "clear")]
     Clean,
+    /// Returns the CLI's current config directory
+    ConfDir,
 }
 
 #[derive(Subcommand)]
@@ -89,6 +91,7 @@ enum AttachmentSubcommand {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
+    dotenvy::dotenv().ok();
 
     match cli.debug {
         0 => {}
@@ -134,6 +137,7 @@ async fn main() -> anyhow::Result<()> {
             AttachmentSubcommand::Remove { id } => attachments::remove(id).await?,
         },
         Commands::Clean => clean::clean().await?,
+        Commands::ConfDir => println!("{}", get_conf_directry()?.display()),
     }
 
     Ok(())

--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -36,7 +36,8 @@ You can find the CLI's current configuration directory using the `eludris conf-d
 command. You can also overwrite the default directory using the `ELUDRIS_CLI_CONF`
 environment variable.
 
-The Eludris CLI automatically reads your `.env` files to facilitate managing multiple instances.
+The Eludris CLI automatically reads your `.env` files in your current directory
+to facilitate managing multiple instances.
 
 ## Commands
 
@@ -143,7 +144,7 @@ This command will remove your Eludris instance along with all the database files
 eludris conf-dir
 ```
 
-This command returns the config directory used by the CLI.
+This command returns the config directory currently used by the CLI.
 
 Depending on whether you have an `.env` file this can change based on your current directory.
 

--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -31,7 +31,12 @@ you want to know.
 
 Upon using the CLI for the first time you will get prompted for some config questions
 namely about where to put the Eludris instance.
-This can be changed at any time by editing the config file found in `~/.config/eludris/Cli.toml`
+
+You can find the CLI's current configuration directory using the `eludris conf-dir`
+command. You can also overwrite the default directory using the `ELUDRIS_CLI_CONF`
+environment variable.
+
+The Eludris CLI automatically reads your `.env` files to facilitate managing multiple instances.
 
 ## Commands
 
@@ -131,3 +136,16 @@ This command will remove your Eludris instance along with all the database files
 > **Note**
 >
 > This will not clean up the docker images, you can remove those using `docker image rm <image names>*`
+
+### Conf-Dir
+
+```sh
+eludris conf-dir
+```
+
+This command returns the config directory used by the CLI.
+
+Depending on whether you have an `.env` file this can change based on your current directory.
+
+You can also supply the `ELUDRIS_CLI_CONF` environment variable to override the default
+configuration directory for your platform.


### PR DESCRIPTION
## Description

This pull request improves the CLI's config directory is handled by introducing two major changes:
- Make the CLI work on Windows and behave better on MacOS using the [directories](https://crates.io/crates/directories) crate's `ProjectDirs::config_dir()` to achieve better cross-platform support.
- Allow the config directory to be manually changed using the `ELUDRIS_CLI_CONF` environment variable.

This pull request also makes the CLI read the current directory's `.env` file and improves upon the `README.md`.

## This is a **Code Change**

- [x] Docs have been updated to reflect these changes if necessary.
- [x] Changes have been tested.
