### PR TITLE
feat(cli): allow users to configure their `.env` file while setting up their instance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,3 @@
-ELUDRIS_CONF = Eludris.toml # the path to your configuration file
-REDIS_URL = redis://127.0.0.1:6379
-DATABASE_URL = mysql://root:root@localhost:3306/eludris
-
-# Don't forget to also change the ports in the docker-compose.yml
-
 # oprish
 OPRISH_PORT = 7159
 
@@ -12,3 +6,9 @@ PANDEMONIUM_PORT = 7160
 
 # effis
 EFFIS_PORT = 7161
+
+# Used when running Eludris outside of Docker
+
+# ELUDRIS_CONF = Eludris.toml # the path to your configuration file
+# REDIS_URL = redis://127.0.0.1:6379
+# DATABASE_URL = mysql://root:root@localhost:3306/eludris

--- a/cli/src/deploy.rs
+++ b/cli/src/deploy.rs
@@ -31,7 +31,7 @@ pub async fn deploy(next: bool) -> anyhow::Result<()> {
         )
         .await?;
         download_file(&config, &client, "docker-compose.override.yml", next, None).await?;
-        download_file(&config, &client, ".example.env", next, Some(".env")).await?;
+        download_file(&config, &client, ".env.example", next, Some(".env")).await?;
         download_file(
             &config,
             &client,

--- a/cli/src/deploy.rs
+++ b/cli/src/deploy.rs
@@ -119,6 +119,28 @@ pub async fn deploy(next: bool) -> anyhow::Result<()> {
                 }
             }
         }
+
+        if Confirm::with_theme(&theme::ColorfulTheme::default())
+            .with_prompt("Do you want to configure your instance's `.env` file?")
+            .interact()
+            .context("Could not spawn confirm prompt")?
+        {
+            let base_env = fs::read_to_string(format!("{}/.env", config.eludris_dir))
+                .await
+                .context("Could not read .env file")?;
+            if let Some(env) = Editor::new()
+                .executable(&editor)
+                .require_save(true)
+                .trim_newlines(false)
+                .edit(&base_env)
+                .context("Could not setup editor")?
+            {
+                fs::write(format!("{}/.env", config.eludris_dir), env)
+                    .await
+                    .context("Could not write new config to .env")?;
+            }
+        };
+
         println!(
             "{}",
             Style::new()

--- a/cli/src/deploy.rs
+++ b/cli/src/deploy.rs
@@ -70,13 +70,13 @@ pub async fn deploy(next: bool) -> anyhow::Result<()> {
             };
             break;
         }
+
         let mut base_conf = fs::read_to_string(format!("{}/Eludris.toml", config.eludris_dir))
             .await
             .context("Could not read Eludris.toml file")?;
         loop {
             let conf = Editor::new()
-                .executable(&editor) // we can't use the default since most people don't have a
-                // default editor set on their root user
+                .executable(&editor)
                 .extension("toml")
                 .require_save(true)
                 .trim_newlines(false)


### PR DESCRIPTION
## Description

This pull request makes it easy to modify yout instance's `.env` file by asking if you want to configure it
when initially setting up your instance, and if so opening it in a similar style to how the `Eludris.toml` was already opened.

The main motivation for this was allowing easier port customization when deploying more than one instance at once.

This pull request also slightly cleans up the pre-existing `.env.example` file.

## This is a **Code Change**

- [x] Docs have been updated to reflect these changes if necessary.
- [x] Changes have been tested.