### PR TITLE
feat(codegen): make the `autodoc` macro ignore struct fields annotated with `serde(skip_serializing)`

### DIFF
--- a/codegen/src/autodoc/utils.rs
+++ b/codegen/src/autodoc/utils.rs
@@ -109,7 +109,7 @@ pub fn get_field_infos<'a, T: Iterator<Item = &'a Field>>(
                         NestedMeta::Meta(Meta::Path(path)) => {
                             if path.is_ident("flatten") {
                                 flattened = true;
-                            } else if path.is_ident("skip") {
+                            } else if path.is_ident("skip") || path.is_ident("skip_serializing") {
                                 continue 'outer;
                             }
                         }


### PR DESCRIPTION
## Description

This pull request makes the `autodoc` macro also ignore fields annotated with `serde(skip_serializing)` like it does with ones annotated with `serde(skip)`.

## This is a **Code Change**

- [x] Docs have been updated to reflect these changes if necessary.
- [x] Changes have been tested.