### PR TITLE
docs: improve the consistency of the documentation of some fields

### DIFF
--- a/todel/src/models/files.rs
+++ b/todel/src/models/files.rs
@@ -27,7 +27,7 @@ pub struct FileData {
     pub name: String,
     /// The bucket the file is stored in.
     pub bucket: String,
-    /// If the file is marked as a spoiler.
+    /// Whether the file is marked as a spoiler.
     #[serde(default = "spoiler_default")]
     #[serde(skip_serializing_if = "is_false")]
     pub spoiler: bool,

--- a/todel/src/models/files.rs
+++ b/todel/src/models/files.rs
@@ -74,18 +74,18 @@ fn spoiler_default() -> bool {
 pub enum FileMetadata {
     Text,
     Image {
-        /// The width of the image in pixels.
+        /// The image's width in pixels.
         #[serde(skip_serializing_if = "Option::is_none")]
         width: Option<usize>,
-        /// The height of the image in pixels.
+        /// The image's height in pixels.
         #[serde(skip_serializing_if = "Option::is_none")]
         height: Option<usize>,
     },
     Video {
-        /// The width of the video in pixels.
+        /// The video's width in pixels.
         #[serde(skip_serializing_if = "Option::is_none")]
         width: Option<usize>,
-        /// The height of the video in pixels.
+        /// The video's height in pixels.
         #[serde(skip_serializing_if = "Option::is_none")]
         height: Option<usize>,
     },

--- a/todel/src/models/files.rs
+++ b/todel/src/models/files.rs
@@ -21,13 +21,13 @@ use serde::{Deserialize, Serialize};
 #[autodoc(category = "Files")]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FileData {
-    /// The ID of the file.
+    /// The file's ID.
     pub id: u64,
-    /// The name of the file.
+    /// The file's name.
     pub name: String,
     /// The bucket the file is stored in.
     pub bucket: String,
-    /// If the file is spoilered.
+    /// If the file is marked as a spoiler.
     #[serde(default = "spoiler_default")]
     #[serde(skip_serializing_if = "is_false")]
     pub spoiler: bool,

--- a/todel/src/models/info.rs
+++ b/todel/src/models/info.rs
@@ -64,13 +64,13 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 #[autodoc(category = "Instance")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstanceInfo {
-    /// The name of the instance.
+    /// The instance's name.
     pub instance_name: String,
-    /// The description of the instance.
+    /// The instance's description.
     ///
     /// This is between 1 and 2048 characters long.
     pub description: Option<String>,
-    /// The Eludris version the instance is running.
+    /// The instance's Eludris version.
     pub version: String,
     /// The maximum length of a message's content.
     pub message_limit: usize,
@@ -138,11 +138,11 @@ pub struct InstanceInfo {
 #[autodoc(category = "Instance")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstanceRateLimits {
-    /// Rate limits for Oprish (The REST API).
+    /// The instance's Oprish rate limit information (The REST API).
     pub oprish: OprishRateLimits,
-    /// Rate limits for Pandemonium (The WebSocket API).
+    /// The instance's Pandemonium rate limit information (The WebSocket API).
     pub pandemonium: RateLimitConf,
-    /// Rate limits for Effis (The CDN).
+    /// The instance's Effis rate limit information (The CDN).
     pub effis: EffisRateLimits,
 }
 

--- a/todel/src/models/messages.rs
+++ b/todel/src/models/messages.rs
@@ -15,11 +15,11 @@ use serde::{Deserialize, Serialize};
 #[autodoc(category = "Messaging")]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Message {
-    /// The author of message. This field has to be between 2 and 32 characters long.
+    /// The message's author. This field has to be between 2 and 32 characters long.
     ///
     /// The author will be trimmed from leading and trailing whitespace.
     pub author: String,
-    /// The content of the message. This field has to be at-least 2 characters long. The upper limit
+    /// The message's content the message. This field has to be at-least 2 characters long. The upper limit
     /// is the instance's [`InstanceInfo`] `message_limit`.
     ///
     /// The content will be trimmed from leading and trailing whitespace.

--- a/todel/src/models/messages.rs
+++ b/todel/src/models/messages.rs
@@ -19,7 +19,7 @@ pub struct Message {
     ///
     /// The author will be trimmed from leading and trailing whitespace.
     pub author: String,
-    /// The message's content the message. This field has to be at-least 2 characters long. The upper limit
+    /// The message's content. This field has to be at-least 2 characters long. The upper limit
     /// is the instance's [`InstanceInfo`] `message_limit`.
     ///
     /// The content will be trimmed from leading and trailing whitespace.


### PR DESCRIPTION
## Description

This pull request was initially started after I've noticing the discrepancy between some of the field documentation style
in the `User` and `FileData` structs. I mentioned this on the Discord server's development channel and got told to
[choose what I preferred](https://discord.com/channels/980412957060137001/1048626763615449138/1112360403343777862).

The main difference was how simple information was presented, it was really inconsistent. For example:
- FileData: `The ID of the File.`
- User: `The user's ID.`

After making the `FileData` struct's fields follow the same style as `User` struct's field, I noticed that the `FileMetadata`, `InstanceInfo` and `Message` structs also followed the old `FileData` style, so I also changed those to follow suit.