### PR TITLE
refactor(todel): only include "private" user fields when the `logic` feature is enabled

### DIFF
--- a/todel/src/models/users.rs
+++ b/todel/src/models/users.rs
@@ -49,12 +49,15 @@ pub struct User {
     /// The user's instance-wide permissions as a bitfield.
     pub permissions: u64,
     /// The user's email address.
+    #[cfg(feature = "logic")]
     #[serde(skip)]
     pub email: String,
     /// The user's password hash.
+    #[cfg(feature = "logic")]
     #[serde(skip)]
     pub password: Vec<u8>,
     /// The user's two-factor authentication secret.
+    #[cfg(feature = "logic")]
     #[serde(skip)]
     pub two_factor_auth: Option<String>,
 }


### PR DESCRIPTION
## Description

This pull request makes it so that the "private" (as in hidden from the end user) fields of the `User` model
are only actually included in the model when they're needed.

The fields in question are the `email`, `password` and `two_factor_auth` fields.

These fields should only be needed by the backend when actually performing logic-related tasks, which is why they've
been locked behind the `logic` feature.

This is important because it allows for much more neat models when todel is used as a crate for providing
Eludris model types for rust client implementations, which, according to the `README.md`, seems to be one of it's main purposes.

## This is a **Code Change**

- [x] Docs have been updated to reflect these changes if necessary.
- [x] Changes have been tested.
