### PR TITLE
refactor(todel): remove the only internally used fields on the `User` struct 

### DIFF
--- a/todel/src/models/users.rs
+++ b/todel/src/models/users.rs
@@ -48,16 +48,4 @@ pub struct User {
     pub badges: u64,
     /// The user's instance-wide permissions as a bitfield.
     pub permissions: u64,
-    /// The user's email address.
-    #[cfg(feature = "logic")]
-    #[serde(skip)]
-    pub email: String,
-    /// The user's password hash.
-    #[cfg(feature = "logic")]
-    #[serde(skip)]
-    pub password: Vec<u8>,
-    /// The user's two-factor authentication secret.
-    #[cfg(feature = "logic")]
-    #[serde(skip)]
-    pub two_factor_auth: Option<String>,
 }


### PR DESCRIPTION
## Description

This pull request removes some fields on the `User` struct which are only ever meant to be used internally by the backend.

These fields are the `email`, `password` and `two_factor_auth` fields.

The rationale behind this change is as follows:
- These fields are only ever used in specific cases where they are mainly fetched decoupled from the other data.
- There is no good reason to keep this data on the end user exposed payload when the end user is never meant to get this data.
- Currently leaving it as is would take more resources for no benefit.

For more information refer to this [message](https://discord.com/channels/980412957060137001/1048626763615449138/1112461204141649920) on the Eludris Discord server.

## This is a **Code Change**

- [x] Docs have been updated to reflect these changes if necessary.
- [x] Changes have been tested.