### PR TITLE
refactor(todel): tidy up the pre-existing `IdGenerator` code

### DIFF
--- a/effis/src/main.rs
+++ b/effis/src/main.rs
@@ -19,7 +19,7 @@ use rocket::{
     Build, Config, Rocket,
 };
 use rocket_db_pools::{deadpool_redis::Pool, sqlx::MySqlPool, Database};
-use todel::{ids::IDGenerator, Conf};
+use todel::{ids::IdGenerator, Conf};
 
 pub const BUCKETS: [&str; 1] = ["attachments"];
 
@@ -89,7 +89,7 @@ fn rocket() -> Result<Rocket<Build>, anyhow::Error> {
         ));
 
     Ok(rocket::custom(config)
-        .manage(Mutex::new(IDGenerator::new()))
+        .manage(Mutex::new(IdGenerator::new()))
         .manage(conf)
         .attach(DB::init())
         .attach(Cache::init())

--- a/effis/src/routes/buckets.rs
+++ b/effis/src/routes/buckets.rs
@@ -2,7 +2,7 @@ use rocket::{form::Form, serde::json::Json, State};
 use rocket_db_pools::Connection;
 use todel::{
     http::ClientIP,
-    ids::IDGenerator,
+    ids::IdGenerator,
     models::{ErrorResponse, FetchResponse, File, FileData, FileUpload},
     Conf,
 };
@@ -47,7 +47,7 @@ pub async fn upload_file<'a>(
     mut cache: Connection<Cache>,
     mut db: Connection<DB>,
     conf: &State<Conf>,
-    gen: &State<Mutex<IDGenerator>>,
+    gen: &State<Mutex<IdGenerator>>,
 ) -> RateLimitedRouteResponse<Json<FileData>> {
     let mut rate_limiter = RateLimiter::new("attachments", bucket, ip, conf.inner());
     rate_limiter
@@ -58,7 +58,7 @@ pub async fn upload_file<'a>(
     let file = File::create(
         upload.file,
         bucket.to_string(),
-        gen.inner(),
+        &mut *gen.inner().lock().await,
         &mut db,
         upload.spoiler,
     )

--- a/effis/src/routes/index.rs
+++ b/effis/src/routes/index.rs
@@ -2,7 +2,7 @@ use rocket::{form::Form, serde::json::Json, State};
 use rocket_db_pools::Connection;
 use todel::{
     http::ClientIP,
-    ids::IDGenerator,
+    ids::IdGenerator,
     models::{FetchResponse, File, FileData, FileUpload},
     Conf,
 };
@@ -45,7 +45,7 @@ pub async fn upload_attachment<'a>(
     mut cache: Connection<Cache>,
     mut db: Connection<DB>,
     conf: &State<Conf>,
-    gen: &State<Mutex<IDGenerator>>,
+    gen: &State<Mutex<IdGenerator>>,
 ) -> RateLimitedRouteResponse<Json<FileData>> {
     let mut rate_limiter = RateLimiter::new("attachments", "attachments", ip, conf.inner());
     rate_limiter
@@ -55,7 +55,7 @@ pub async fn upload_attachment<'a>(
     let file = File::create(
         upload.file,
         "attachments".to_string(),
-        gen.inner(),
+        &mut *gen.inner().lock().await,
         &mut db,
         upload.spoiler,
     )

--- a/todel/src/ids/mod.rs
+++ b/todel/src/ids/mod.rs
@@ -19,7 +19,7 @@ lazy_static! {
 ///
 /// let mut generator = IdGenerator::new(); // Create a new ID generator.
 ///
-/// generator.generate_id(); // Generate an ID which also increments the sequence.
+/// generator.generate(); // Generate an ID which also increments the sequence.
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct IdGenerator {
@@ -42,7 +42,7 @@ impl IdGenerator {
     }
 
     /// Generate a new ID and handle incrementing the sequence
-    pub fn generate_id(&mut self) -> u64 {
+    pub fn generate(&mut self) -> u64 {
         if self.sequence == u8::MAX {
             self.sequence = 0
         } else {
@@ -66,11 +66,11 @@ mod tests {
     fn id_generator() {
         let mut generator = IdGenerator::new();
 
-        let id = generator.generate_id();
+        let id = generator.generate();
         assert_eq!(id & 0xFF, 1);
         assert_eq!(id >> 8 & 0xFF, 0);
 
-        let id = generator.generate_id();
+        let id = generator.generate();
         assert_eq!(id & 0xFF, 2);
         assert_eq!(id >> 8 & 0xFF, 0);
     }
@@ -82,15 +82,15 @@ mod tests {
             worker_id: 3,
         };
 
-        let id = generator.generate_id();
+        let id = generator.generate();
         assert_eq!(id & 0xFF, u8::MAX as u64);
         assert_eq!(id >> 8 & 0xFF, generator.worker_id as u64);
 
-        let id = generator.generate_id();
+        let id = generator.generate();
         assert_eq!(id & 0xFF, 0);
         assert_eq!(id >> 8 & 0xFF, generator.worker_id as u64);
 
-        let id = generator.generate_id();
+        let id = generator.generate();
         assert_eq!(id & 0xFF, 1);
         assert_eq!(id >> 8 & 0xFF, generator.worker_id as u64);
     }

--- a/todel/src/ids/mod.rs
+++ b/todel/src/ids/mod.rs
@@ -15,20 +15,20 @@ lazy_static! {
 /// ## Example
 ///
 /// ```rust
-/// use todel::ids::IDGenerator;
+/// use todel::ids::IdGenerator;
 ///
-/// let mut generator = IDGenerator::new(); // Create a new ID generator.
+/// let mut generator = IdGenerator::new(); // Create a new ID generator.
 ///
 /// generator.generate_id(); // Generate an ID which also increments the sequence.
 /// ```
 #[derive(Debug, Clone, Default)]
-pub struct IDGenerator {
+pub struct IdGenerator {
     sequence: u8,
     worker_id: u8,
 }
 
-impl IDGenerator {
-    /// Create a new IDGenerator from an instance ID.
+impl IdGenerator {
+    /// Create a new IdGenerator from an instance ID.
     pub fn new() -> Self {
         Self {
             sequence: 0,
@@ -60,11 +60,11 @@ impl IDGenerator {
 
 #[cfg(test)]
 mod tests {
-    use super::IDGenerator;
+    use super::IdGenerator;
 
     #[test]
     fn id_generator() {
-        let mut generator = IDGenerator::new();
+        let mut generator = IdGenerator::new();
 
         let id = generator.generate_id();
         assert_eq!(id & 0xFF, 1);
@@ -77,7 +77,7 @@ mod tests {
 
     #[test]
     fn id_generator_overflow() {
-        let mut generator = IDGenerator {
+        let mut generator = IdGenerator {
             sequence: u8::MAX - 1,
             worker_id: 3,
         };

--- a/todel/src/models/logic/files.rs
+++ b/todel/src/models/logic/files.rs
@@ -57,7 +57,7 @@ impl File {
             ));
         }
 
-        let id = gen.lock().await.generate_id();
+        let id = id_generator.generate();
         let path = PathBuf::from(format!("files/{}/{}", bucket, id));
         let name = match file.raw_name() {
             Some(name) => PathBuf::from(name.dangerous_unsafe_unsanitized_raw().as_str())

--- a/todel/src/models/logic/files.rs
+++ b/todel/src/models/logic/files.rs
@@ -8,10 +8,10 @@ use rocket::{
     FromForm, Responder,
 };
 use sqlx::{pool::PoolConnection, MySql};
-use tokio::{fs, sync::Mutex};
+use tokio::fs;
 
 use crate::error;
-use crate::ids::IDGenerator;
+use crate::ids::IdGenerator;
 use crate::models::{ErrorResponse, File, FileData, FileMetadata};
 
 #[derive(Debug, Responder)]
@@ -46,7 +46,7 @@ impl File {
     pub async fn create<'a>(
         mut file: TempFile<'a>,
         bucket: String,
-        gen: &Mutex<IDGenerator>,
+        id_generator: &mut IdGenerator,
         db: &mut PoolConnection<MySql>,
         spoiler: bool,
     ) -> Result<FileData, ErrorResponse> {


### PR DESCRIPTION
## Description

This pull request tidies up the pre-existing `IdGenerator` code by changing the following:
- Renaming it from `IDGenerator` to `IdGenerator` to conform to PascalCase naming standards.
- Renaming `IdGenerator::generate_id` to `IdGenerator::generate` to be more consistent with more popular rust code.
- Take a mutable reference to `IdGenerator` instead of a mutex in the `File::create` method for cleaner code and "correcter" separation of concerns.

## This is a **Code Change**

- [x] Docs have been updated to reflect these changes if necessary.
- [x] Changes have been tested.