### PR TITLE
Ceilia/unauthorized forbidden error responses

### DIFF
--- a/todel/src/http/response.rs
+++ b/todel/src/http/response.rs
@@ -10,9 +10,11 @@ use crate::models::ErrorResponse;
 impl<'r> Responder<'r, 'static> for ErrorResponse {
     fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
         let status = match &self {
-            ErrorResponse::RateLimited { shared, .. } => shared.status,
-            ErrorResponse::Validation { shared, .. } => shared.status,
+            ErrorResponse::Unauthorized { shared, .. } => shared.status,
+            ErrorResponse::Forbidden { shared, .. } => shared.status,
             ErrorResponse::NotFound { shared, .. } => shared.status,
+            ErrorResponse::Validation { shared, .. } => shared.status,
+            ErrorResponse::RateLimited { shared, .. } => shared.status,
             ErrorResponse::Server { shared, .. } => shared.status,
         };
         response::Response::build_from(Json(self).respond_to(req)?)

--- a/todel/src/models/response.rs
+++ b/todel/src/models/response.rs
@@ -95,7 +95,7 @@ pub enum ErrorResponse {
     },
     /// The error when a client is rate limited.
     ///
-    /// ------
+    /// -----
     ///
     /// ### Example
     ///


### PR DESCRIPTION
## Description

This pull request adds the `Unauthorized` and `Forbidden` status codes to the pre-existing `ErrorResponse` logic.

I've also taken the liberty of organising the responses to follow the ascending order of the numerical status codes.

<details>
  <summary>
    The new variants' docs preview
  </summary>
  <img alt="Documentation page for Unauthorized and Forbidden" src="https://media.discordapp.net/attachments/1112768116871680043/1112768241211809792/image.png" />
  <blockquote>
    <b>Note</b>
    <br />
    <p>The tables' borders look weird mainly due to my zooming out to fit everything into one screenshot. Additionally, even when zoomed in it doesn't look as bad as the screenshot, not sure why.</p>
  </blockquote>
</details>

## This is a **Code Change**

- [x] Docs have been updated to reflect these changes if necessary.
- [x] Changes have been tested.